### PR TITLE
chore: update p2p milestone for devnet

### DIFF
--- a/src/devnet/milestones.json
+++ b/src/devnet/milestones.json
@@ -90,5 +90,11 @@
     {
         "height": 5636000,
         "aip36": true
-    }
+    },
+    {
+        "height": 5640857,
+        "p2p": {
+            "minimumVersions": ["^3.0 || ^3.0.0-next.0"]
+        }
+    }    
 ]


### PR DESCRIPTION
## Summary

Devnet still inherits a `minimumVersions` value of `["^2.6 || ^2.6.0-next.9"]` instead of `["^3.0 || ^3.0.0-next.0"]` which was set in a previous milestone, overriding the value in `defaults.ts`. This PR sets `minimumVersions` to `["^3.0 || ^3.0.0-next.0"]` from the height of the first unvote+vote transaction, i.e. the point where a stock Core 2.x would fork anyway even if the p2p layer was the same.

This is necessary so that version `3.0.0` (i.e. final release without any `-next.X` suffix) and any subsequent versions will be accepted on devnet.

## Checklist

<!-- Have you done all of these things?  -->

- [x] Ready to be merged

<!-- Feel free to add additional comments. -->
