### PR TITLE
chore: add AIP37 activation milestone

### DIFF
--- a/src/mainnet/milestones.json
+++ b/src/mainnet/milestones.json
@@ -63,5 +63,9 @@
     {
         "height": 13705000,
         "aip36": true
+    },
+    {
+        "height": 17632000,
+        "aip37": true
     }
 ]


### PR DESCRIPTION
Add AIP37 (https://github.com/ArkEcosystem/AIPs/blob/master/AIPS/aip-37.md) activation block at height 17,632,000.
