### PR TITLE
chore: add p2p milestone for mainnet

### DIFF
--- a/src/mainnet/milestones.json
+++ b/src/mainnet/milestones.json
@@ -67,5 +67,11 @@
     {
         "height": 17632000,
         "aip37": true
+    },
+    {
+        "height": 21235300,
+        "p2p": {
+            "minimumVersions": [">=3.5.0"]
+        }
     }
 ]


### PR DESCRIPTION
## Summary

Set `p2p.minimumVersions` milestone on block height **21235300**. Minimum p2p version is set to **3.5.0**. 

## Checklist

- [x] Ready to be merged

